### PR TITLE
Deleted gen_hunt_twolegs patrols

### DIFF
--- a/resources/dicts/patrols/hunting/hunting.json
+++ b/resources/dicts/patrols/hunting/hunting.json
@@ -189,47 +189,6 @@
         "antagonize_fail_text": null
     },
     {
-        "patrol_id": "gen_hunt_twolegs1",
-        "biome": "Any",
-        "season": "Any",
-        "tags": ["hunting"],
-        "intro_text": "The patrol approaches a Twoleg nest while hunting.",
-        "success_text": ["The patrol has a successful hunt, avoiding any Twolegs."],
-        "fail_text": ["Twoleg kits scare the patrol away."],
-        "decline_text": "The patrol decides to hunt elsewhere.",
-        "chance_of_success": 40,
-        "exp": 10,
-        "win_skills": ["great hunter", "fantastic hunter"],
-        "min_cats": 1,
-        "max_cats": 6,
-        "antagonize_text": null,
-        "antagonize_fail_text": null
-    },
-    {
-        "patrol_id": "gen_hunt_twolegs2",
-        "biome": "Any",
-        "season": "Any",
-        "tags": ["gone", "hunting"],
-        "intro_text": "The smell of food lures r_c close to a Twoleg trap.",
-        "success_text": [
-            "r_c grabs the food before the trap goes off.",
-            "r_c cautiously sticks their paw through the shiny mesh and scoops some of the food out. Not as good as prey, but it'll feed a cat or two.",
-            "s_c maneuvers the trap onto its side. It rattles as it snaps closed, but the food is still on the ground where it was, having fallen through the mesh. s_c quickly makes off with their prize."],
-        "fail_text": [
-            "r_c tries to stick their paw into the trap and barely manages to snatch it back as the trap snaps closed. Close one! But now there's no way to get the food.",
-            "s_c boldly walks up to the trap and attempts to grab the food. They're barely able to jump back as the trap snaps closed.",
-            "r_c is caught in the trap. Despite the patrol's attempts, Twolegs soon arrive and take the trap with the cat inside."],
-        "decline_text": "r_c loses interest and walks back to the patrol.",
-        "chance_of_success": 40,
-        "exp": 10,
-        "win_skills": ["very smart", "extremely smart"],
-        "fail_trait": ["bold"],
-        "min_cats": 1,
-        "max_cats": 6,
-        "antagonize_text": null,
-        "antagonize_fail_text": null
-    },
-    {
         "patrol_id": "gen_hunt_vision1",
         "biome": "Any",
         "season": "Any",


### PR DESCRIPTION
Gen_hunt_twoleg1 and 2 have been replaced with _hunt_twolegtrap1 and 2 for all biomes, so the old gen non-specific version can be deleted now.