### PR TITLE
Sucess rate changes + remove vixen patrols

### DIFF
--- a/resources/dicts/patrols/training/training.json
+++ b/resources/dicts/patrols/training/training.json
@@ -6,7 +6,7 @@
     "tags": ["herbs", "training", "injury", "poisoned", "comfort", "trust"],
     "intro_text": "While out training, r_c stumbles upon a bush of red berries.",
     "decline_text": "r_c decides not to touch the berries.",
-    "chance_of_success": 50,
+    "chance_of_success": 80,
     "exp": 20,
     "success_text": [
         "Unsure but remembering the kittentales of red deathberries, r_c avoids them, and gives the rest of the patrol a head's up about the potentially dangerous bush.",
@@ -32,7 +32,7 @@
     "tags": ["herbs", "training", "apprentice", "injury", "poisoned", "death"],
     "intro_text": "While helping gathering herbs, r_c stumbles upon a bush of red berries.",
     "decline_text": "r_c decides not to touch the berries.",
-    "chance_of_success": 50,
+    "chance_of_success": 80,
     "exp": 20,
     "success_text": [
         "Unsure but remembering the kittentales of red deathberries, app1 avoids them and alerts the patrol, who, extremely worried, confirm that this a a deathberry bush.",
@@ -56,7 +56,7 @@
     "tags": ["herbs", "training", "injury", "poisoned"],
     "intro_text": "While helping gathering herbs, r_c stumbles upon a bush of red berries.",
     "decline_text": "r_c decides not to touch the berries.",
-    "chance_of_success": 50,
+    "chance_of_success": 80,
     "exp": 20,
     "success_text": [
         "Unsure but remembering the kittentales of red deathberries, r_c avoids them, and gives the rest of the patrol a head's up about the potentially dangerous bush.",
@@ -82,7 +82,7 @@
     "tags": ["herbs", "training", "apprentice", "injury", "poisoned", "death"],
     "intro_text": "While helping gathering herbs, r_c stumbles upon a bush of red berries.",
     "decline_text": "r_c decides not to touch the berries.",
-    "chance_of_success": 50,
+    "chance_of_success": 80,
     "exp": 20,
     "success_text": [
         "Unsure but remembering the kittentales of red deathberries, app1 avoids them and alerts the patrol, who, extremely worried, confirm that this a a deathberry bush.",
@@ -106,7 +106,7 @@
     "tags": ["platonic", "training"],
     "intro_text": "The patrol finds a nice spot to sun themselves.",
     "decline_text": "They decide to stay focused instead.",
-    "chance_of_success": 80,
+    "chance_of_success": 90,
     "exp": 20,
     "success_text": [
         "The sunlight feels great and the cats have a successful training session, swapping tips and advice as they stretch out and bask.",
@@ -131,7 +131,7 @@
     "tags": ["training"],
     "intro_text": "r_c finds a nice spot to sun themselves.",
     "decline_text": "They decide to stay focused instead.",
-    "chance_of_success": 40,
+    "chance_of_success": 80,
     "exp": 20,
     "success_text": [
         "The sunlight energizes r_c for a solo training session."
@@ -151,7 +151,7 @@
     "tags": ["training", "dislike", "comfort", "respect", "trust", "patrol_to_p_l"],
     "intro_text": "Your patrol has a disagreement and look to p_l to settle the dispute.",
     "decline_text": "Your patrol decides to head home.",
-    "chance_of_success": 50,
+    "chance_of_success": 70,
     "exp": 20,
     "success_text": [
         "p_l manages to skillfully smooth over any disagreement.",
@@ -180,7 +180,7 @@
     "tags": ["training", "dislike", "comfort", "respect", "trust", "patrol_to_p_l"],
     "intro_text": "Your patrol has a disagreement and look to p_l to settle the dispute.",
     "decline_text": "Your patrol decides to head home.",
-    "chance_of_success": 50,
+    "chance_of_success": 70,
     "exp": 20,
     "success_text": [
         "p_l manages to skillfully smooth over any disagreement.",
@@ -209,7 +209,7 @@
     "tags": ["training", "respect", "trust", "jealousy", "patrol_to_r_c"],
     "intro_text": "As the patrol gathers together to train under p_l's leadership, r_c admits they think they had a vision from StarClan last night.",
     "decline_text": "The patrol doesn't talk about the vision.",
-    "chance_of_success": 40,
+    "chance_of_success": 70,
     "exp": 20,
     "success_text": [
         "The patrol talks to them about whether it was a real vision as they train.",
@@ -233,7 +233,7 @@
     "tags": ["training"],
     "intro_text": "As they head out to work on their skills, r_c thinks about the dream they had last night . . . was it sent by Starclan?",
     "decline_text": "They push it from their mind.",
-    "chance_of_success": 40,
+    "chance_of_success": 70,
     "exp": 20,
     "success_text": [
         "It definitely distracts them from their training, but r_c uses the time by themselves to put their thoughts in order. It was a sign from their ancestors. Now they need to figure out what to do next.",
@@ -256,10 +256,10 @@
     "tags": ["training", "platonic"],
     "intro_text": "The patrol quickly devolves into ghost stories, leaving everyone on edge.",
     "decline_text": "p_l quickly silences any talk about ghosts.",
-    "chance_of_success": 40,
+    "chance_of_success": 80,
     "exp": 20,
     "success_text": [
-        "Despite the tense mood, the patrol is successful.",
+        "Despite the tense mood, the patrol is successful, and as the afternoon wears on the cats relax with each other.",
         "r_c spins a thrilling tale, and the patrol shivers with exciting, thrilled fear.",
         "s_c sees the patrol competing to scare each other, and derails it completely. Instead they spin a tale of truth, bringing the story of one of c_n's warrior ancestors to life. With how clear their words are, it's almost like they know the Starclan cat, even though that's impossible."
     ],
@@ -279,7 +279,7 @@
     "tags": ["training", "platonic", "dislike", "apprentice", "two_apprentices"],
     "intro_text": "The patrol quickly devolves into ghost stories, leaving everyone on edge.",
     "decline_text": "p_l quickly silences any talk about ghosts.",
-    "chance_of_success": 40,
+    "chance_of_success": 80,
     "exp": 20,
     "success_text": [
         "app2 and app1 wind each other up, making up story after story in ever increasing tales of horror, until finally one sounds a little too ridiculous and both of them nearly fall over laughing, the tension erased as they giggle.",
@@ -304,7 +304,7 @@
     "tags": ["training", "apprentice", "disrespect", "distrust", "clan_to_r_c"],
     "intro_text": "app1 is tempted to eat the prey they just caught. After all, they're only practicing hunting, right? So this is theirs, it doesn't count as a true hunting patrol?",
     "decline_text": "app1 decides against breaking the warrior code, resisting the temptation.",
-    "chance_of_success": 40,
+    "chance_of_success": 60,
     "exp": 20,
     "success_text": [
         "They eat the prey without anyone noticing, and return to camp, thrilled with their little transgression.",
@@ -330,7 +330,7 @@
     "tags": ["training", "apprentice", "disrespect", "distrust", "clan_to_r_c"],
     "intro_text": "app1 is tempted to eat the prey they just caught. After all, they're only practicing hunting, right? So this is theirs, it doesn't count as a true hunting patrol?",
     "decline_text": "app1 decides against breaking the warrior code, resisting the temptation.",
-    "chance_of_success": 40,
+    "chance_of_success": 60,
     "exp": 20,
     "success_text": [
         "They eat the prey without anyone noticing, and return to camp, thrilled with their little transgression.",
@@ -356,7 +356,7 @@
     "tags": ["training", "apprentice", "disrespect", "distrust", "clan_to_r_c"],
     "intro_text": "app1 is tempted to eat the prey they just caught. After all, they're only practicing hunting, right? So this is theirs, it doesn't count as a true hunting patrol?",
     "decline_text": "app1 decides against breaking the warrior code, resisting the temptation.",
-    "chance_of_success": 40,
+    "chance_of_success": 60,
     "exp": 20,
     "success_text": [
         "They eat the prey without anyone noticing, and return to camp, thrilled with their little transgression.",
@@ -382,7 +382,7 @@
     "tags": ["training", "apprentice", "disrespect", "distrust", "clan_to_r_c"],
     "intro_text": "app1 is tempted to eat the prey they just caught. After all, they're only practicing hunting, right? So this is theirs, it doesn't count as a true hunting patrol?",
     "decline_text": "app1 decides against breaking the warrior code, resisting the temptation.",
-    "chance_of_success": 40,
+    "chance_of_success": 60,
     "exp": 20,
     "success_text": [
         "They eat the prey without anyone noticing, and return to camp, thrilled with their little transgression.",
@@ -500,7 +500,7 @@
     "tags": ["training", "platonic", "trust"],
     "intro_text": "p_l suggests this might be a good chance for the cats to practice new hunting techniques.",
     "decline_text": "They decide to focus on working on a different skill instead.",
-    "chance_of_success": 60,
+    "chance_of_success": 80,
     "exp": 20,
     "success_text": [
         "Everyone has a nice practice session, picking up a nice selection of new tricks to try out on their next hunting patrol.",
@@ -523,7 +523,7 @@
     "tags": ["training", "platonic", "trust"],
     "intro_text": "p_l suggests this might be a good chance to practice new hunting techniques with r_c.",
     "decline_text": "They decide to focus on working on a different skill instead.",
-    "chance_of_success": 60,
+    "chance_of_success": 80,
     "exp": 20,
     "success_text": [
         "Both cats have a nice practice session, swapping their best tips and tricks with each other.",
@@ -546,7 +546,7 @@
     "tags": ["training", "platonic", "trust", "apprentice"],
     "intro_text": "p_l suggests this might be a good chance for the cats to practice new hunting techniques, particularly with app1 with them.",
     "decline_text": "They decide to focus on working on a different skill instead.",
-    "chance_of_success": 60,
+    "chance_of_success": 80,
     "exp": 20,
     "success_text": [
         "Everyone has a nice practice session, picking up a nice selection of new tricks to try out on their next hunting patrol. app1 really gets into it, and is praised for their focus and enthusiasm.",
@@ -569,7 +569,7 @@
     "tags": ["training", "platonic", "trust", "apprentice"],
     "intro_text": "p_l suggests this might be a good chance to practice new hunting techniques with app1.",
     "decline_text": "They decide to focus on working on a different skill instead.",
-    "chance_of_success": 60,
+    "chance_of_success": 80,
     "exp": 20,
     "success_text": [
         "Both cats have a nice practice session, with app1 soaking up all p_l's best tips and tricks.",
@@ -592,7 +592,7 @@
     "tags": ["training", "platonic", "trust"],
     "intro_text": "p_l suggests this might be a good chance for the cats to practice new fighting techniques.",
     "decline_text": "They decide to focus on working on a different skill instead.",
-    "chance_of_success": 60,
+    "chance_of_success": 80,
     "exp": 20,
     "success_text": [
         "Everyone has a nice practice session, picking up a nice selection of new tricks to try out in their next skirmish.",
@@ -615,7 +615,7 @@
     "tags": ["training", "platonic", "trust"],
     "intro_text": "p_l suggests this might be a good chance to practice new fighting techniques with r_c.",
     "decline_text": "They decide to focus on working on a different skill instead.",
-    "chance_of_success": 60,
+    "chance_of_success": 80,
     "exp": 20,
     "success_text": [
         "Both cats have a nice practice session, swapping their best tips and tricks with each other.",
@@ -638,7 +638,7 @@
     "tags": ["training", "platonic", "trust", "apprentice"],
     "intro_text": "p_l suggests this might be a good chance for the cats to practice new fighting techniques, particularly with app1 here to learn from them.",
     "decline_text": "They decide to focus on working on a different skill instead.",
-    "chance_of_success": 60,
+    "chance_of_success": 80,
     "exp": 20,
     "success_text": [
         "Everyone has a nice practice session, picking up a nice selection of new tricks to try out in their next skirmish. app1 really gets into it, and is praised for their focus and enthusiasm.",
@@ -661,7 +661,7 @@
     "tags": ["training", "platonic", "trust", "apprentice"],
     "intro_text": "p_l suggests this might be a good chance to practice new fighting techniques with app1.",
     "decline_text": "They decide to focus on working on a different skill instead.",
-    "chance_of_success": 60,
+    "chance_of_success": 80,
     "exp": 20,
     "success_text": [
         "Both cats have a nice practice session, with app1 soaking up all p_l's best tips and tricks.",
@@ -676,290 +676,5 @@
     "max_cats": 2,
     "antagonize_text": null,
     "antagonize_fail_text": null
-},
-{
-    "patrol_id": "gen_train_vixen1",
-    "biome": "Any",
-    "season": "newleaf",
-    "tags": ["fighting", "death", "scar", "battle_injury", "respect", "trust"],
-    "intro_text": "Your patrol catches the scent of a fox.",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 30,
-    "exp": 30,
-    "success_text": [
-        "The vixen smells of milk, and hopefully by driving her out of the territory, her litter this Newleaf won't be a threat to the clan.",
-        "Your patrol drives away the fox, seeks out her den, and kills her young cubs.",
-        "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the fox nor her cubs pose a threat to the clan.",
-        "The patrol overcomes the vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment."
-    ],
-    "fail_text": [
-        "The mother fox is vicious and determined, and the small patrol is beaten back.",
-        "s_c is determined to win, but their confidence is misplaced, and the vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up the fight.",
-        "Never threaten a mother's young - the vixen kills r_c in the skirmish.",
-        "The mother fox's snapping jaws leave a permanent mark on r_c, and force the patrol to back off."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-        "r_c carries a scar from a fox fight.",
-        "r_c fell in battle with a fox."
-    ]
-},
-{
-    "patrol_id": "gen_train_vixen2",
-    "biome": "Any",
-    "season": "newleaf",
-    "tags": ["fighting", "death", "scar", "battle_injury", "respect", "trust"],
-    "intro_text": "Your patrol catches the scent of a fox.",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 30,
-    "exp": 30,
-    "success_text": [
-    "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the fox, seeks out her den, and kills her young cubs.",
-    "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the mother vixen and ending the threat to the clan that she and her cubs pose.",
-    "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the fox nor her cubs pose a threat to the clan.",
-    "The patrol overcomes the vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment."
-    ],
-    "fail_text": [
-    "The mother fox is vicious and determined, but although they lose this battle, through teamwork the cats manage to retreat without injury.",
-    "s_c is determined to win, but their confidence is misplaced, and the vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up the fight.",
-    null,
-    "r_c is left with a small scar, as the patrol and the mother vixen fight to a stalemate."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-    "r_c carries a scar from a fox fight."
-    ]
-},
-{
-    "patrol_id": "gen_train_vixen3",
-    "biome": "Any",
-    "season": "newleaf",
-    "tags": ["fighting", "death", "scar", "battle_injury", "respect", "trust", "no_body"],
-    "intro_text": "Your patrol catches the scent of a fox.",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 20,
-    "exp": 50,
-    "success_text": [
-    null,
-    "The vixen smells of milk, and hopefully by driving her out of the territory, her litter this Newleaf won't be a threat to the clan.",
-    "s_c displays incredible skill, driving the mother vixen out of the territory all by themselves. Now neither the fox nor her cubs pose a threat to the clan.",
-    "A brilliant battle move by s_c at a critical moment knocks the vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it."
-    ],
-    "fail_text": [
-    null,
-    "s_c is determined to win, but the vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way.",
-    "Never threaten a mother's young - the vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
-    "The mother fox's snapping jaws leave a permanent mark on r_c, and force the patrol to back off."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-    "r_c carries a scar from a solo fight with a vixen.",
-    "r_c fell in a solo battle with a vixen."
-    ]
-},
-{
-    "patrol_id": "gen_train_vixen4",
-    "biome": "Any",
-    "season": "greenleaf",
-    "tags": ["fighting", "death", "scar", "battle_injury", "respect", "trust"],
-    "intro_text": "Your patrol catches the scent of a fox.",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 30,
-    "exp": 30,
-    "success_text": [
-    "The vixen smells of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this Greenleaf won't be a threat to the clan.",
-    "Your patrol drives away the fox, seeks out her den, and kills her cubs.",
-    "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the fox nor her cubs pose a threat to the clan.",
-    "The patrol overcomes the vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment."
-    ],
-    "fail_text": [
-    "The mother fox is vicious and determined, and the small patrol is beaten back.",
-    "s_c is determined to win, but their confidence is misplaced, and the vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up the fight.",
-    "Never threaten a mother's young - the vixen kills r_c in the skirmish.",
-    "The mother fox's snapping jaws leave a permanent mark on r_c, and force the patrol to back off."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-    "r_c carries a scar from a fox fight.",
-    "r_c fell in battle with a fox."
-    ]    
-},
-{
-    "patrol_id": "gen_train_vixen5",
-    "biome": "Any",
-    "season": "greenleaf",
-    "tags": ["fighting", "death", "scar", "battle_injury", "respect", "trust"],
-    "intro_text": "Your patrol catches the scent of a fox.",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 30,
-    "exp": 30,
-    "success_text": [
-    "Led by p_l, and with a heap of cooperation and teamwork, the patrol drives away the fox, seeks out her den, and kills her growing cubs.",
-    "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the mother vixen and ending the threat to the clan that she and her cubs pose.",
-    "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the fox nor her cubs pose a threat to the clan.",
-    "The patrol overcomes the vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment."
-    ],
-    "fail_text": [
-    "The mother fox is vicious and determined, but although they lose this battle, through teamwork the cats manage to retreat without injury.",
-    "s_c is determined to win, but their confidence is misplaced, and the vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up the fight.",
-    null,
-    "r_c is left with a small scar, as the patrol and the mother vixen fight to a stalemate."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-    "r_c carries a scar from a fox fight."
-    ]
-},
-{
-    "patrol_id": "gen_train_vixen6",
-    "biome": "Any",
-    "season": "greenleaf",
-    "tags": ["fighting", "death", "scar", "battle_injury", "respect", "trust", "no_body"],
-    "intro_text": "Your patrol catches the scent of a fox.",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 10,
-    "exp": 50,
-    "success_text": [
-    null,
-    "The vixen smells of milk and blood. Hopefully by driving her out of the territory, the litter she has been raising this Greenleaf won't be a threat to the clan.",
-    "s_c displays incredible skill, driving the mother vixen out of the territory all by themselves. Now neither the fox nor her cubs pose a threat to the clan.",
-    "A brilliant battle move by s_c at a critical moment knocks the vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it."
-    ],
-    "fail_text": [
-    null,
-    "s_c is determined to win, but the vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way.",
-    "Never threaten a mother's young - the vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
-    "The mother fox's snapping jaws leave a permanent mark on r_c, and force the patrol to back off."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-    "r_c carries a scar from a solo fight with a vixen.",
-    "r_c fell in a solo battle with a vixen."
-    ]
-},
-{
-    "patrol_id": "gen_train_vixen7",
-    "biome": "Any",
-    "season": "leaf-fall",
-    "tags": ["fighting", "death", "scar", "battle_injury", "respect", "trust"],
-    "intro_text": "Your patrol catches the scent of a fox.",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 30,
-    "exp": 30,
-    "success_text": [
-    "The vixen smells like the prey she's been poaching to feed her litter. She's stolen from c_n for the last time, and the patrol drives her from their territory, yowling their anger.",
-    "Your patrol drives away the fox, and seeks out her den, but her Leaf-fall cubs are near full-grown, and scatter from the patrol into the wilderness. Hopefully Leaf-bare takes care of them.",
-    "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the fox nor her cubs pose a threat to the clan.",
-    "The patrol overcomes the vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment."
-    ],
-    "fail_text": [
-    "The mother fox is vicious and determined, and the small patrol is beaten back.",
-    "s_c is determined to win, but their confidence is misplaced, and the vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up the fight.",
-    "Never threaten a mother's young - the vixen kills r_c in the skirmish.",
-    "The mother fox's snapping jaws leave a permanent mark on r_c, and force the patrol to back off."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "min_cats": 2,
-    "max_cats": 3,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-    "r_c carries a scar from a fox fight.",
-    "r_c fell in battle with a fox."
-    ]
-},
-{
-    "patrol_id": "gen_train_vixen8",
-    "biome": "Any",
-    "season": "leaf-fall",
-    "tags": ["fighting", "death", "scar", "battle_injury", "respect", "trust"],
-    "intro_text": "Your patrol catches the scent of a fox.",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 30,
-    "exp": 30,
-    "success_text": [
-    "Led by p_l and with a heap of cooperation and teamwork, the patrol drives away the fox, and seeks out her den. But her cubs are near full-grown with the bounty of Leaf-fall, and scatter from the patrol into the wilderness. Hopefully Leaf-bare takes care of them.",
-    "With so many cats working together in tight coordination, they manage to accomplish the near-impossible, killing the mother vixen and ending the threat to the clan that she poses. The patrol drives her near-full grown litter of fox cubs out from the territory. Hopefully the coming Leaf-bare will take care of them.",
-    "s_c displays incredible skill, driving the mother vixen out of the territory almost by themselves. Now neither the fox nor her cubs pose a threat to c_n.",
-    "The patrol overcomes the vixen and drives her off thanks to a brilliant battle move by s_c at a critical moment."
-    ],
-    "fail_text": [
-    "The mother fox is vicious and determined, but although they lose this battle, through teamwork the cats manage to retreat without injury.",
-    "s_c is determined to win, but their confidence is misplaced, and the vixen manages to sink her teeth into them. The patrol rallies around s_c, but they have to give up the fight.",
-    null,
-    "r_c is left with a small scar, as the patrol and the mother vixen fight to a stalemate."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "min_cats": 4,
-    "max_cats": 6,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-    "r_c carries a scar from a fox fight."
-    ]
-},
-{
-    "patrol_id": "gen_train_vixen9",
-    "biome": "Any",
-    "season": "leaf-fall",
-    "tags": ["fighting", "death", "scar", "battle_injury", "respect", "trust", "no_body"],
-    "intro_text": "Your patrol catches the scent of a fox.",
-    "decline_text": "Your patrol decides not to pursue the fox.",
-    "chance_of_success": 20,
-    "exp": 50,
-    "success_text": [
-    null,
-    "It takes r_c's every bit of bravery and strength to drives away the vixen - her near grown litter, fat on the bounty of Leaf-fall, is a challenge for another day.",
-    "s_c displays incredible skill, driving the mother vixen out of the territory all by themselves. Now neither the fox nor her cubs pose a threat to the clan.",
-    "A brilliant battle move by s_c at a critical moment knocks the vixen off balance, and s_c manages to drive her out of c_n territory, though it takes every spark of strength in their pelt to do it."
-    ],
-    "fail_text": [
-    null,
-    "s_c is determined to win, but the vixen is determined to live, and that makes all the difference. s_c ends up pinned in a defensible hiding spot, bleeding and terrified, until the vixen judges them no longer a threat and continues on her way.",
-    "Never threaten a mother's young - the vixen kills r_c in the skirmish, and carries off the body to feed her litter.",
-    "The mother fox's snapping jaws leave a permanent mark on r_c, and force the patrol to back off."
-    ],
-    "win_skills": ["excellent fighter"],
-    "win_trait": ["adventurous", "altruistic", "ambitious", "bloodthirsty", "bold", "confident", "daring", "fierce", "responsible", "righteous", "troublesome", "vengeful"],
-    "min_cats": 1,
-    "max_cats": 1,
-    "antagonize_text": null,
-    "antagonize_fail_text": null,
-    "history_text": [
-    "r_c carries a scar from a solo fight with a vixen.",
-    "r_c fell in a solo battle with a vixen."
-    ]
 }
 ]


### PR DESCRIPTION
Success rate changes for nearly everything
gen_train_ghost1 expanded success text 
_teamwork patrols no change to success rate.
Vixen patrols removed.