### PR TITLE
Edits for leader otherclan patrols

### DIFF
--- a/resources/dicts/patrols/other_clan.json
+++ b/resources/dicts/patrols/other_clan.json
@@ -3,7 +3,7 @@
         "patrol_id": "gen_border_otherclan1",
         "biome": "Any",
         "season": "Any",
-        "tags": ["border", "other_clan"],
+        "tags": ["border", "no_leader", "other_clan"],
         "intro_text": "While walking along the border, your patrol notices a o_c_n patrol renewing their scent marks up ahead.",
         "decline_text": "Your patrol decides to avoid the other clan cats.",
         "chance_of_success": 60,
@@ -34,7 +34,7 @@
         "patrol_id": "gen_border_otherclan2",
         "biome": "Any",
         "season": "Any",
-        "tags": ["border", "other_clan"],
+        "tags": ["border", "no_leader", "other_clan"],
         "intro_text": "While walking along the border, your patrol notices a o_c_n patrol renewing their scent marks up ahead.",
         "decline_text": "Your patrol decides to avoid the other clan cats.",
         "chance_of_success": 60,
@@ -50,7 +50,7 @@
         "s_c pins their ears at the sight of the o_c_n cats. As the patrols cross paths, s_c's aggression is obvious and the other patrol definitely notices. While they don't remark on the hostility, your patrol gets the sense that the rude behavior has been noted."
         ],
         "other_clan": ["None"],
-        "win_skills": ["'smart'", "great 'smart'", "excellent 'smart'"],
+        "win_skills": ["smart", "very smart", "extremely smart"],
         "win_trait": ["adventurous", "bold", "daring", "shameless", "troublesome", "playful", "childish"],
         "fail_skills": ["None"],
         "fail_trait": ["vengeful", "bloodthirsty", "righteous", "vengeful", "cold"],
@@ -94,6 +94,68 @@
         ]
         },
         {
+        "patrol_id": "gen_border_otherclan4",
+        "biome": "Any",
+        "season": "Any",
+        "tags": ["border", "leader", "other_clan"],
+        "intro_text": "While walking along the border, your patrol notices a o_c_n patrol renewing their scent marks up ahead.",
+        "decline_text": "Your patrol decides to avoid the other clan cats.",
+        "chance_of_success": 60,
+        "exp": 10,
+        "success_text": [
+        "When the two patrols get closer to each other the patrol leader from o_c_n gives p_l a respectful nod, which they return. The patrols refocus on their tasks without stopping for a conversation, but a feeling of mutual respect has been fostered.",
+        "The other patrol greets p_l respectfully, remarking on the weather and enquirying politely about the youngest members of the clan. p_l smiles, impressed with them.",
+        "Once the patrols cross paths, s_c is quick to break the awkward atmosphere with a friendly greeting and easy conversation. The two patrols eventually return to their tasks feeling confident in their good relations with the opposite clan.",
+        "Once the patrols cross paths, s_c is quick to break the awkward atmosphere with a friendly greeting and easy conversation. The two patrols eventually return to their tasks feeling confident in their good relations with the opposite clan."
+        ],
+        "fail_text": [
+        "The patrols eventually cross paths and an awkward tension fills the air. No one is quite sure what to say to break the silence and eventually everyone involved slowly shuffles away to continue their respective patrols.",
+        "s_c bounds ahead to the other patrol, not bothering to greet them or exchange pleasantries before remarking on the funny smell of the other clan cats. Offended, the other patrol stalks away, their tails whipping and ears pinned."
+        ],
+        "other_clan": ["None"],
+        "win_skills": ["good speaker", "great speaker", "excellent speaker"],
+        "win_trait": ["altruistic", "calm", "charismatic", "confident", "wise"],
+        "fail_skills": ["None"],
+        "fail_trait": ["troublesome", "strange", "playful", "daring", "childish"],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": "Your patrol stands tall and approaches the o_c_n cats with insults and threats. They need to be sure that o_c_n knows how strong c_n cats are. r_c spits and hisses until the other patrol leaves the area, intimidated by how your patrol is acting.",
+        "antagonize_fail_text": "Your patrol stands tall and approaches the o_c_n cats with insults and threats. They need to be sure that o_c_n knows how strong c_n cats are. r_c spits and hisses until the other patrol leaves the area, annoyed and unimpressed by your patrol's posturing.",
+        "history_text": [
+        ]
+    },
+    {
+        "patrol_id": "gen_border_otherclan5",
+        "biome": "Any",
+        "season": "Any",
+        "tags": ["border", "leader", "other_clan"],
+        "intro_text": "While walking along the border, your patrol notices a o_c_n patrol renewing their scent marks up ahead.",
+        "decline_text": "Your patrol decides to avoid the other clan cats.",
+        "chance_of_success": 60,
+        "exp": 10,
+        "success_text": [
+        "When the two patrols get closer to each other the patrol leader from o_c_n gives p_l a respectful nod, which they return. The patrols refocus on their tasks without stopping for a conversation, but a feeling of mutual respect has been fostered.",
+        "The other patrol greets p_l respectfully, remarking on the weather and enquirying politely about the youngest members of the clan. p_l smiles, impressed with them.",
+        "Once the patrols cross paths, s_c is quick to break the awkward atmosphere with a friendly greeting and easy conversation. s_c remembers some of the news that o_c_n shared at a recent gathering and brings it up, impressing the other patrol with their polite interest.",
+        "Once the patrols cross paths, s_c is quick to break the awkward atmosphere with a friendly greeting. The patrols pause to converse for a little while, s_c bringing up a story that, while slightly embarrassing for s_c, is entertaining and lighthearted. The patrols part in good spirits."
+        ],
+        "fail_text": [
+        "The patrols eventually cross paths and an awkward tension fills the air. No one is quite sure what to say to break the silence and eventually everyone involved slowly shuffles away to continue their respective patrols.",
+        "s_c pins their ears at the sight of the o_c_n cats. As the patrols cross paths, s_c's aggression is obvious and the other patrol definitely notices. While they don't remark on the hostility, your patrol gets the sense that the rude behavior has been noted."
+        ],
+        "other_clan": ["None"],
+        "win_skills": ["smart", "very smart", "extremely smart"],
+        "win_trait": ["adventurous", "bold", "daring", "shameless", "troublesome", "playful", "childish"],
+        "fail_skills": ["None"],
+        "fail_trait": ["vengeful", "bloodthirsty", "righteous", "vengeful", "cold"],
+        "min_cats": 2,
+        "max_cats": 6,
+        "antagonize_text": "Your patrol stands tall and approaches the o_c_n cats with insults and threats. They need to be sure that o_c_n knows how strong c_n cats are. r_c spits and hisses until the other patrol leaves the area, intimidated by how your patrol is acting.",
+        "antagonize_fail_text": "Your patrol stands tall and approaches the o_c_n cats with insults and threats. They need to be sure that o_c_n knows how strong c_n cats are. r_c spits and hisses until the other patrol leaves the area, annoyed and unimpressed by your patrol's posturing.",
+        "history_text": [
+        ]
+    },    
+    {
         "patrol_id": "gen_med_borderherb1",
         "biome": "Any",
         "season": "leaf-bare",


### PR DESCRIPTION
gen_border_otherclan1 and gen_border_otherclan2 have had the no leader tag added.  gen_border_otherclan2 has had the win skills fixed.  gen_border_otherclan4 and gen_border_otherclan5 added to give leaders an option for gen_border_otherclan patrols