### PR TITLE
patrol proofreading & neutrois queens, also bugfixes

### DIFF
--- a/resources/dicts/patrols/hunting/hunting_desert.json
+++ b/resources/dicts/patrols/hunting/hunting_desert.json
@@ -730,8 +730,8 @@
             "Refusing to stop hunting, app1 bodly decides to go into a canyon where it'll be cooler. They don't find any prey, but don't overheat either.",
             "app1 doesn't make it back to camp. A patrol sent out for them find their body, collapsed in a shadeless part of the territory and already starting to dry out and mummify.",
             "app1 collapses from heat exhaustion while trying to position themselves for a hunt. They're able to move to the shade, but the hunt is over, and it's only when a clanmate finds them that they're able to totter home shakily.",
-            "When s_c doesn't return to camp that evening, a search patry goes out for them. They find app1 collapsed and badly affected by heat stroke, and carry them back to camp where their might be a way to help them. However, app1's breathing stops on the journey home, and they slip to Starclan.",
-            "When s_c doesn't return to camp that evening, a search patry goes out for them. They find app1 collapsed and badly affected by heat stroke, and carry them back to camp where their might be a way to help them."
+            "When s_c doesn't return to camp that evening, a search party goes out for them. They find app1 collapsed and badly affected by heat stroke, and carry them back to camp where their might be a way to help them. However, app1's breathing stops on the journey home, and they slip to StarClan.",
+            "When s_c doesn't return to camp that evening, a search party goes out for them. They find app1 collapsed and badly affected by heat stroke, and carry them back to camp where their might be a way to help them."
         ],
         "win_skills": [
             "None"

--- a/resources/dicts/patrols/hunting/hunting_wetlands.json
+++ b/resources/dicts/patrols/hunting/hunting_wetlands.json
@@ -1527,7 +1527,7 @@
         "chance_of_success": 50,
         "exp": 20,
         "success_text": [
-            "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to Starclan they throw themselves into battle, and the fox, already half full of food and unwilling to lose blood over it, is driven off from the kill.",
+            "Your cats are smaller but they outnumber the fox, if only by a little, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full of food and unwilling to lose blood over it, is driven off from the kill.",
             null,
             "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until it gives up and runs.",
             "The patrol launches into battle, but with so few cats it's exhausting trying to keep the fox and its snapping jaws on the defensive. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. It's only one bite, but the fox has had enough and flees."
@@ -1592,7 +1592,7 @@
         "chance_of_success": 80,
         "exp": 20,
         "success_text": [
-            "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to Starclan they throw themselves into battle, and the fox, already half full and unwilling to lose blood over it, is driven off from the kill.",
+            "Your cats are smaller but heavily outnumber the fox, and it's a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle, and the fox, already half full and unwilling to lose blood over it, is driven off from the kill.",
             null,
             "s_c shows their strength, leading the fight against the fox. By working together and keeping it distracted, the cats harry and harass the fox until s_c lands a crucial blow, snapping a tendon in one of the fox's hindlegs. The fox runs, but there's no way it'll live long with such a crippling injury.",
             "The patrol launches into battle, keeping the fox on the defensive with teamwork. In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. Holding on grimly, s_c's daring move gives the rest of the patrol the opportunity needed to bring the fox down for good."
@@ -1655,7 +1655,7 @@
         "chance_of_success": 30,
         "exp": 30,
         "success_text": [
-            "r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to Starclan they throw themselves into battle. The fox, already stuffed full and unwilling to lose blood over it, leaves the kill with a grumble.",
+            "r_c smaller, alone, and half its weight, but the fox has a prize they're willing to fight for. With a prayer to StarClan they throw themselves into battle. The fox, already stuffed full and unwilling to lose blood over it, leaves the kill with a grumble.",
             null,
             "s_c uses every trick in their talented fighting skillset to attack the fox with no one to watch their flank, until the perfect opportunity opens up and they pounce onto the fox's back, digging in their claws. It's a wild ride through the forest until the fox bucks them off, but it wins them the eel carcass.",
             "In an act of daring bravery, s_c darts low to the ground, gets under the jaws, and sinks their teeth into the fox's throat. But then they're stuck, unwilling to let go and risk being bitten. They're dragged through the forest, over rocks and through bushes, until the fox finally collapses and the battered s_c goes back to proudly claim the eel."

--- a/resources/dicts/patrols/new_cat.json
+++ b/resources/dicts/patrols/new_cat.json
@@ -73,7 +73,7 @@
         "biome": "Any",
         "season": "Any",
         "tags": ["border", "new_cat", "new_cat_kit", "reputation"],
-        "intro_text": "r_c finds an abandoned kit whose mother is nowhere to be found.",
+        "intro_text": "r_c finds an abandoned kit whose parents are nowhere to be found.",
         "success_text": [
             "The kit is taken back to camp and nursed back to health."
         ],
@@ -149,11 +149,11 @@
         "chance_of_success": 45,
         "exp": 10,
         "success_text": [
-                "The sounds die away and then start up again in strange, unpredictable intervals. Investigating, p_l suddenly finds themself nose to nose with a panting, bleeding queen, one deseperately trying to keep her newborn litter quiet. p_l brings her back to camp, where the clan can assist.",
+                "The sounds die away and then start up again in strange, unpredictable intervals. Investigating, p_l suddenly finds themself nose to nose with a panting, bleeding queen, one desperately trying to keep their newborn litter quiet. p_l brings the queen back to camp, where the clan can assist.",
                 "p_l follows the strange sounds on the wind and finds a struggling queen with their newborn kits clinging to them. r_c sprints back to camp to find help while p_l tries to make the queen eat some strengthening herbs. Thankful for the help the queen joins c_n with their kits."
         ],
         "fail_text": [
-                "p_l follows the strange sounds on the wind and finds the body of a unknown queen, with her kits beside her slowly going cold. r_c goes back to camp to find help bringing their bodies back to camp to pay respects."
+                "p_l follows the strange sounds on the wind and finds the bodies of a unknown queen with their kits beside them, slowly going cold. r_c goes back to camp to find help bringing their bodies back to camp to pay respects."
         ],
         "win_skills": ["None"],
         "win_trait": ["None"],
@@ -175,10 +175,10 @@
         "exp": 10,
         "success_text": [
                 "p_l, sure that it is a sign of StarClan, follows the faint wailing. Instead they find a queen who lost their life in a harsh kitting, their newborn kits clinging to a body that will never move again. p_l instantly wraps themselves around the kits and orders r_c back to camp to find help and a queen willing to nurse them.",
-                "It takes ages for p_l to pin point the sounds, but eventually they uncover the hidden birthing nest of a dead, cold queen, her newborn kits by her side. p_l makes sure the queen is given a vigil - as her kits grow, they'll have questions about her."
+                "It takes ages for p_l to pin point the sounds, but eventually they uncover the hidden birthing nest of a dead, cold queen, their newborn kits by their side. p_l makes sure the queen is given a vigil - as the kits grow older, they'll have questions about their parent."
         ],
         "fail_text": [
-                "p_l follows the strange sounds on the wind and finds the body of a unknown queen, with her kits beside her slowly going cold. r_c goes back to camp to find help bringing their bodies back to camp to pay respects."
+                "p_l follows the strange sounds on the wind and finds the bodies of a unknown queen with their kits beside them, slowly going cold. r_c goes back to camp to find help bringing their bodies back to camp to pay respects."
         ],
         "win_skills": ["None"],
         "win_trait": ["None"],
@@ -199,11 +199,11 @@
         "chance_of_success": 45,
         "exp": 10,
         "success_text": [
-                "The sounds die away and then start up again in strange, unpredictable intervals. Investigating, p_l suddenly finds themself nose to nose with a panting, bleeding queen, one deseperately trying to keep her newborn litter quiet. p_l brings her back to camp, where the clan can assist.",
-                "p_l follows the strange sounds on the wind and finds a struggling queen with their newborn kits clinging to them. p_l tries to make the queen eat some strengthening herbs, and slowly helps her back to camp. Thankful for the help the queen joins c_n with their kits."
+                "The sounds die away and then start up again in strange, unpredictable intervals. Investigating, p_l suddenly finds themself nose to nose with a panting, bleeding queen, one desperately trying to keep their newborn litter quiet. p_l brings the queen back to camp, where the clan can assist.",
+                "p_l follows the strange sounds on the wind and finds a struggling queen with their newborn kits clinging to them. p_l tries to make the queen eat some strengthening herbs, and slowly helps them back to camp. Thankful for the help the queen joins c_n with their kits."
         ],
         "fail_text": [
-                "p_l follows the strange sounds on the wind and finds the body of a unknown queen, with her kits beside her slowly going cold. They cancel their patrol and return to camp, to get help sending these lost souls to StarClan."
+                "p_l follows the strange sounds on the wind and finds the bodies of an unknown queen with their kits beside them, slowly going cold. They cancel their patrol and return to camp to get help sending these lost souls to StarClan."
         ],
         "win_skills": ["None"],
         "win_trait": ["None"],
@@ -225,10 +225,10 @@
         "exp": 10,
         "success_text": [
                 "p_l, sure that it is a sign of StarClan, follows the faint wailing. Instead they find a queen who lost their life in a harsh kitting, their newborn kits clinging to a body that will never move again. p_l instantly wraps themselves around the kits and starts thinking about what they'll need to do to move them to camp.",
-                "It takes ages for p_l to pin point the sounds, but eventually they uncover the hidden birthing nest of a dead, cold queen, her newborn kits by her side. p_l makes sure the queen is given a vigil - as her kits grow, they'll have questions about her."
+                "It takes ages for p_l to pin point the sounds, but eventually they uncover the hidden birthing nest of a dead, cold queen, their newborn kits by their side. p_l makes sure the queen is given a vigil - as the kits grow older, they'll have questions about their parent."
         ],
         "fail_text": [
-                "p_l follows the strange sounds on the wind and finds the bodies of a unknown queen, with her kits beside her slowly going cold. They cancel their patrol and return to camp, to get help sending these lost souls to StarClan."
+                "p_l follows the strange sounds on the wind and finds the bodies of an unknown queen with their kits beside them, slowly going cold. They cancel their patrol and return to camp to get help sending these lost souls to StarClan."
         ],
         "win_skills": ["None"],
         "win_trait": ["None"],
@@ -249,11 +249,11 @@
         "chance_of_success": 45,
         "exp": 10,
         "success_text": [
-                "The sounds die away and then start up again in strange, unpredictable intervals. Investigating, app1 suddenly finds themself nose to nose with a panting, bleeding queen, one deseperately trying to keep her newborn litter quiet. They run for home, dseperate to bring her help.",
-                "app1 follows the strange sounds on the wind and finds a struggling queen with their newborn kits clinging to them. Panicking, they ask her to hold on just a little longer while they fetch help, and sprint for home, yowling in case any patrol is nearby to assist."
+                "The sounds die away and then start up again in strange, unpredictable intervals. Investigating, app1 suddenly finds themself nose to nose with a panting, bleeding queen, one desperately trying to keep their newborn litter quiet. They run for home, desperate to bring help.",
+                "app1 follows the strange sounds on the wind and finds a struggling queen with their newborn kits clinging to them. Panicking, they ask the queen to hold on just a little longer while they fetch help, then sprint for home, yowling in case any patrol is nearby to assist."
         ],
         "fail_text": [
-                "app1 follows the strange sounds on the wind and finds the bodies of a unknown queen, with her kits beside her slowly going cold. They desperately try to save a kitten, but can't, and their mentor find them there sobbing hours later."
+                "app1 follows the strange sounds on the wind and finds the bodies of an unknown queen with their kits beside them, slowly going cold. They desperately try to save a kitten, but can't, and their mentor finds them there sobbing hours later."
         ],
         "win_skills": ["None"],
         "win_trait": ["None"],
@@ -275,10 +275,10 @@
         "exp": 10,
         "success_text": [
                 "app1, sure that it is a sign of StarClan, follows the faint wailing. Instead they find a queen who lost their life in a harsh kitting, their newborn kits clinging to a body that will never move again. app1 tries to comfort the poor kittens, trying to share their body heat, and wails until a passing patrol hears them.",
-                "It takes ages for app1 to pin point the sounds, but eventually they uncover the hidden birthing nest of a dead, cold queen, her newborn kits by her side. app1 vows to be the new kits family, to make sure they'll grow up loved and accepted."
+                "It takes ages for app1 to pin point the sounds, but eventually they uncover the hidden birthing nest of a dead, cold queen, their newborn kits by their side. app1 vows to be the new kits' family, to make sure they'll grow up loved and accepted."
         ],
         "fail_text": [
-                "app1 follows the strange sounds on the wind and finds the bodies of a unknown queen, with her kits beside her slowly going cold. They desperately try to save a kitten, but can't, and their mentor find them there sobbing hours later."
+                "app1 follows the strange sounds on the wind and finds the bodies of an unknown queen with their kits beside them, slowly going cold. They desperately try to save a kitten, but can't, and their mentor finds them there sobbing hours later."
         ],
         "win_skills": ["None"],
         "win_trait": ["None"],

--- a/resources/dicts/patrols/new_cat_hostile.json
+++ b/resources/dicts/patrols/new_cat_hostile.json
@@ -73,7 +73,7 @@
     "biome": "Any",
     "season": "Any",
     "tags": ["border", "new_cat", "new_cat_kit", "reputation"],
-    "intro_text": "r_c finds an abandoned kit whose mother is nowhere to be found.",
+    "intro_text": "r_c finds an abandoned kit whose parents are nowhere to be found.",
     "success_text": [
         "The kit is taken back to camp and nursed back to health."
     ],
@@ -180,11 +180,11 @@
     "chance_of_success": 45,
     "exp": 10,
     "success_text": [
-            "The sounds die away and then start up again in strange, unpredictable intervals. Investigating, p_l suddenly finds themself nose to nose with a panting, bleeding queen, one deseperately trying to keep her newborn litter quiet. p_l brings her back to camp, where the clan, suspicious but obediant to the code, takes her in.",
+            "The sounds die away and then start up again in strange, unpredictable intervals. Investigating, p_l suddenly finds themself nose to nose with a panting, bleeding queen, one desperately trying to keep their newborn litter quiet. p_l brings the queen back to camp, where the clan, suspicious but obedient to the code, takes them in.",
             "p_l sees a worn and weary queen protecting their mewling litter. Not happy but unwilling and unable to go against their beloved code they take them back to camp, refusing to let r_c say a word against it."
     ],
     "fail_text": [
-            "p_l sees the bodies of an unknown queen and their kits slowly cooling in the morning breeze. They are filled with an unexpected sense of grief and p_l and the rest of the patrol take the time to carry and bury them outside their borders."
+            "p_l sees the bodies of an unknown queen with their kits beside them, slowly cooling in the morning breeze. They are filled with an unexpected sense of grief and p_l and the rest of the patrol take the time to carry and bury them outside their borders."
     ],
     "win_skills": ["None"],
     "win_trait": ["None"],
@@ -206,10 +206,10 @@
     "exp": 10,
     "success_text": [
             "p_l, sure that it is a sign of StarClan, follows the faint wailing. Instead they find a queen who lost their life in a harsh kitting, their newborn kits clinging to a body that will never move again. p_l hesitates, but wraps themselves around the kits and orders r_c back to the camp to fetch help. They're going to have to argue to keep them.",
-            "p_l and their patrol comes across frantically mewling kits desperately trying to wake up their dead mother. Unsure but not willing for them to die they bring the kits back to the clan to be raised as one of them."
+            "p_l and their patrol comes across frantically mewling kits desperately trying to wake up their dead parent. Unsure but not willing for them to die they bring the kits back to the clan to be raised as one of them."
     ],
     "fail_text": [
-            "p_l sees the bodies of an unknown queen and their kits slowly cooling in the morning breeze. They are filled with an unexpected sense of grief and p_l and the rest of the patrol take the time to carry and bury them outside their borders."
+            "p_l sees the bodies of an unknown queen with their kits beside them, slowly cooling in the morning breeze. They are filled with an unexpected sense of grief and p_l and the rest of the patrol take the time to carry and bury them outside their borders."
     ],
     "win_skills": ["None"],
     "win_trait": ["None"],
@@ -230,11 +230,11 @@
     "chance_of_success": 45,
     "exp": 10,
     "success_text": [
-            "The sounds die away and then start up again in strange, unpredictable intervals. Investigating, p_l suddenly finds themself nose to nose with a panting, bleeding queen, one deseperately trying to keep her newborn litter quiet. p_l brings her back to camp, where the clan, suspicious but obediant to the code, takes her in.",
+            "The sounds die away and then start up again in strange, unpredictable intervals. Investigating, p_l suddenly finds themself nose to nose with a panting, bleeding queen, one desperately trying to keep their newborn litter quiet. p_l brings the queen back to camp, where the clan, suspicious but obedient to the code, takes them in.",
             "p_l sees a worn and weary queen protecting their mewling litter. Not happy but unwilling and unable to go against their beloved code they take them back to camp."
     ],
     "fail_text": [
-            "p_l sees the bodies of an unknown queen and their kits slowly cooling in the morning breeze. They are filled with an unexpected sense of grief and take the time to carry and bury them outside their borders."
+            "p_l sees the bodies of an unknown queen with their kits beside them, slowly cooling in the morning breeze. They are filled with an unexpected sense of grief and take the time to carry and bury them outside their borders."
     ],
     "win_skills": ["None"],
     "win_trait": ["None"],
@@ -256,10 +256,10 @@
     "exp": 10,
     "success_text": [
             "p_l, sure that it is a sign of StarClan, follows the faint wailing. Instead they find a queen who lost their life in a harsh kitting, their newborn kits clinging to a body that will never move again. p_l hesitates, but wraps themselves around the kits. They're going to have to argue to keep them.",
-            "p_l comes across frantically mewling kits desperately trying to wake up their dead mother. Unsure but not willing for them to die they bring the kits back to the clan to be raised as one of them."
+            "p_l comes across frantically mewling kits desperately trying to wake up their dead parent. Unsure but not willing for them to die they bring the kits back to the clan to be raised as one of them."
     ],
     "fail_text": [
-            "p_l sees the bodies of an unknown queen and their kits slowly cooling in the morning breeze. They are filled with an unexpected sense of grief and take the time to carry and bury them outside their borders."
+            "p_l sees the bodies of an unknown queen with their kits beside them, slowly cooling in the morning breeze. They are filled with an unexpected sense of grief and take the time to carry and bury them outside their borders."
     ],
     "win_skills": ["None"],
     "win_trait": ["None"],
@@ -280,11 +280,11 @@
     "chance_of_success": 45,
     "exp": 10,
     "success_text": [
-            "The sounds die away and then start up again in strange, unpredictable intervals. Investigating, app1 suddenly finds themself nose to nose with a panting, bleeding queen, one deseperately trying to keep her newborn litter quiet. They watch uncertainly, but when she begs for help they can't refuse.",
+            "The sounds die away and then start up again in strange, unpredictable intervals. Investigating, app1 suddenly finds themself nose to nose with a panting, bleeding queen, one desperately trying to keep their newborn litter quiet. They watch uncertainly, but when the queen begs for help they can't refuse.",
             "app1 follows the strange sounds on the wind and finds a struggling queen with their newborn kits clinging to them. Panicking, they run for home. It alerts c_n tp the problem, and begrudingly they take the queen and kits in."
     ],
     "fail_text": [
-            "app1 sees the bodies of an unknown queen and their kits slowly cooling in the morning breeze. They are filled with an unexpected sense of grief and take the time to carry and bury them outside their borders."
+            "app1 sees the bodies of an unknown queen with their kits beside them, slowly cooling in the morning breeze. They are filled with an unexpected sense of grief and take the time to carry and bury them outside their borders."
     ],
     "win_skills": ["None"],
     "win_trait": ["None"],
@@ -305,11 +305,11 @@
     "chance_of_success": 45,
     "exp": 10,
     "success_text": [
-            "app1 comes across frantically mewling kits desperately trying to wake up their dead mother. Unsure but not willing for them to die they bring the kits back to the clan to be raised as one of them.",
-            "It takes ages for app1 to pin point the sounds. Eventually they uncover the hidden birthing nest of a dead, cold queen, her newborn kits by her side. It's against everything app1 has been told about outsiders, but they can't leave the kittens to die."
+            "app1 comes across frantically mewling kits desperately trying to wake up their dead parent. Unsure but not willing for them to die they bring the kits back to the clan to be raised as one of them.",
+            "It takes ages for app1 to pin point the sounds. Eventually they uncover the hidden birthing nest of a dead, cold queen, their newborn kits by their side. It's against everything app1 has been told about outsiders, but they can't leave the kittens to die."
     ],
     "fail_text": [
-            "app1 sees the bodies of an unknown queen and their kits slowly cooling in the morning breeze. They are filled with an unexpected sense of grief and take the time to carry and bury them outside their borders."
+            "app1 sees the bodies of an unknown queen with their kits beside them, slowly cooling in the morning breeze. They are filled with an unexpected sense of grief and take the time to carry and bury them outside their borders."
     ],
     "win_skills": ["None"],
     "win_trait": ["None"],

--- a/resources/dicts/patrols/new_cat_welcoming.json
+++ b/resources/dicts/patrols/new_cat_welcoming.json
@@ -73,7 +73,7 @@
     "biome": "Any",
     "season": "Any",
     "tags": ["border", "new_cat", "new_cat_kit", "reputation"],
-    "intro_text": "r_c finds an abandoned kit whose mother is nowhere to be found.",
+    "intro_text": "r_c finds an abandoned kit whose parents are nowhere to be found.",
     "success_text": [
         "r_c rushes the kit back to camp. The kit is nursed back to health and promised a place in the Clan."
     ],
@@ -81,7 +81,7 @@
         "The kit is rushed back to camp, but grows weak and dies a few days later.",
         "The patrol approaches the kit, only to realize that it's already gone. They say a small prayer and bury it."
     ],
-    "decline_text": "The patrol goes to approach when the mother cat appears, sliding out her claws in defense of her baby. Nevermind!",
+    "decline_text": "The patrol goes to approach when the missing queen appears, sliding out their claws in defense of their baby. Nevermind!",
     "antagonize_text": "Your patrol can't bear to leave the kit alone, so they take it to the border of the closest clan and wait for a patrol to arrive. The other clan agrees to take the kit.",
     "antagonize_fail_text": "Your patrol attempts to take the kit to a neighboring clan instead of leaving it, but it dies on the journey. They give it a small burial.",
     "chance_of_success": 60,
@@ -181,11 +181,11 @@
     "chance_of_success": 45,
     "exp": 10,
     "success_text": [
-            "The sounds die away and then start up again in strange, unpredictable intervals. Investigating, p_l suddenly finds themself nose to nose with a panting, bleeding queen, one deseperately trying to keep her newborn litter quiet. p_l brings her back to camp, where the clan can assist.",
+            "The sounds die away and then start up again in strange, unpredictable intervals. Investigating, p_l suddenly finds themself nose to nose with a panting, bleeding queen, one desperately trying to keep their newborn litter quiet. p_l brings the queen back to camp, where the clan can assist.",
             "p_l follows the strange sounds on the wind and finds a struggling queen with their newborn kits clinging to them. r_c sprints back to camp to find help while p_l tries to make the queen eat some strengthening herbs. Thankful for the help the queen joins c_n with their kits."
     ],
     "fail_text": [
-            "p_l follows the strange sounds on the wind and finds the bodies of a unknown queen, with her kits slowly going cold. r_c goes back to camp to find help bringing their bodies back to camp to pay respects."
+            "p_l follows the strange sounds on the wind and finds the bodies of an unknown queen with their kits beside them, slowly going cold. r_c goes back to camp to find help bringing their bodies back to camp to pay respects."
     ],
     "win_skills": ["None"],
     "win_trait": ["None"],
@@ -207,10 +207,10 @@
     "exp": 10,
     "success_text": [
             "p_l, sure that it is a sign of StarClan, follows the faint wailing. Instead they find a queen who lost their life in a harsh kitting, their newborn kits clinging to a body that will never move again. p_l instantly wraps themselves around the kits and orders r_c back to camp to find help and a queen willing to nurse them.",
-            "It takes ages for p_l to pin point the sounds, but eventually they uncover the hidden birthing nest of a dead, cold queen, her newborn kits by her side. p_l makes sure the queen is given a vigil - as her kits grow, they'll have questions about her."
+            "It takes ages for p_l to pin point the sounds, but eventually they uncover the hidden birthing nest of a dead, cold queen, their newborn kits by their side. p_l makes sure the queen is given a vigil - as the kits grow older, they'll have questions about their parent."
     ],
     "fail_text": [
-            "p_l follows the strange sounds on the wind and finds the bodies of a unknown queen, with her kits slowly going cold. r_c goes back to camp to find help bringing their bodies back to camp to pay respects."
+            "p_l follows the strange sounds on the wind and finds the bodies of an unknown queen with their kits beside them, slowly going cold. r_c goes back to camp to find help bringing their bodies back to camp to pay respects."
     ],
     "win_skills": ["None"],
     "win_trait": ["None"],
@@ -231,11 +231,11 @@
     "chance_of_success": 45,
     "exp": 10,
     "success_text": [
-            "The sounds die away and then start up again in strange, unpredictable intervals. Investigating, p_l suddenly finds themself nose to nose with a panting, bleeding queen, one deseperately trying to keep her newborn litter quiet. p_l brings her back to camp, where the clan can assist.",
-            "p_l follows the strange sounds on the wind and finds a struggling queen with their newborn kits clinging to them. p_l tries to make the queen eat some strengthening herbs, and slowly helps her back to camp. Thankful for the help the queen joins c_n with their kits."
+            "The sounds die away and then start up again in strange, unpredictable intervals. Investigating, p_l suddenly finds themself nose to nose with a panting, bleeding queen, one desperately trying to keep their newborn litter quiet. p_l brings the queen back to camp, where the clan can assist.",
+            "p_l follows the strange sounds on the wind and finds a struggling queen with their newborn kits clinging to them. p_l tries to make the queen eat some strengthening herbs, and slowly helps them back to camp. Thankful for the help the queen joins c_n with their kits."
     ],
     "fail_text": [
-            "p_l follows the strange sounds on the wind and finds the bodies of a unknown queen, with her kits slowly going cold. They cancel their patrol and return to camp, to get help sending these lost souls to StarClan."
+            "p_l follows the strange sounds on the wind and finds the bodies of an unknown queen with their kits beside them, slowly going cold. They cancel their patrol and return to camp to get help sending these lost souls to StarClan."
     ],
     "win_skills": ["None"],
     "win_trait": ["None"],
@@ -257,10 +257,10 @@
     "exp": 10,
     "success_text": [
             "p_l, sure that it is a sign of StarClan, follows the faint wailing. Instead they find a queen who lost their life in a harsh kitting, their newborn kits clinging to a body that will never move again. p_l instantly wraps themselves around the kits and starts thinking about what they'll need to do to move them to camp.",
-            "It takes ages for p_l to pin point the sounds, but eventually they uncover the hidden birthing nest of a dead, cold queen, her newborn kits by her side. p_l makes sure the queen is given a vigil - as her kits grow, they'll have questions about her."
+            "It takes ages for p_l to pin point the sounds, but eventually they uncover the hidden birthing nest of a dead, cold queen, their newborn kits by their side. p_l makes sure the queen is given a vigil - as the kits grow older, they'll have questions about their parent."
     ],
     "fail_text": [
-            "p_l follows the strange sounds on the wind and finds the bodies of a unknown queen, with her kits slowly going cold. They cancel their patrol and return to camp, to get help sending these lost souls to StarClan."
+            "p_l follows the strange sounds on the wind and finds the bodies of an unknown queen with their kits beside them, slowly going cold. They cancel their patrol and return to camp to get help sending these lost souls to StarClan."
     ],
     "win_skills": ["None"],
     "win_trait": ["None"],
@@ -281,11 +281,11 @@
     "chance_of_success": 45,
     "exp": 10,
     "success_text": [
-            "The sounds die away and then start up again in strange, unpredictable intervals. Investigating, app1 suddenly finds themself nose to nose with a panting, bleeding queen, one deseperately trying to keep her newborn litter quiet. They run for home, dseperate to bring her help.",
-            "app1 follows the strange sounds on the wind and finds a struggling queen with their newborn kits clinging to them. Panicking, they ask her to hold on just a little longer while they fetch help, and sprint for home, yowling in case any patrol is nearby to assist."
+            "The sounds die away and then start up again in strange, unpredictable intervals. Investigating, app1 suddenly finds themself nose to nose with a panting, bleeding queen, one desperately trying to keep their newborn litter quiet. They run for home, desperate to bring help.",
+            "app1 follows the strange sounds on the wind and finds a struggling queen with their newborn kits clinging to them. Panicking, they ask the queen to hold on just a little longer while they fetch help, then sprint for home, yowling in case any patrol is nearby to assist."
     ],
     "fail_text": [
-            "app1 follows the strange sounds on the wind and finds the bodies of a unknown queen, with her kits slowly going cold. They desperately try to save a kitten, but can't, and their mentor find them there sobbing hours later."
+            "app1 follows the strange sounds on the wind and finds the bodies of an unknown queen with their kits beside them, slowly going cold. They desperately try to save a kitten, but can't, and their mentor fin them there sobbing hours later."
     ],
     "win_skills": ["None"],
     "win_trait": ["None"],
@@ -307,10 +307,10 @@
     "exp": 10,
     "success_text": [
             "app1, sure that it is a sign of StarClan, follows the faint wailing. Instead they find a queen who lost their life in a harsh kitting, their newborn kits clinging to a body that will never move again. app1 tries to comfort the poor kittens, trying to share their body heat, and wails until a passing patrol hears them.",
-            "It takes ages for app1 to pin point the sounds, but eventually they uncover the hidden birthing nest of a dead, cold queen, her newborn kits by her side. app1 vows to be the new kits family, to make sure they'll grow up loved and accepted."
+            "It takes ages for app1 to pin point the sounds, but eventually they uncover the hidden birthing nest of a dead, cold queen, their newborn kits by their side. app1 vows to be the new kits' family, to make sure they'll grow up loved and accepted."
     ],
     "fail_text": [
-            "app1 follows the strange sounds on the wind and finds the bodies of a unknown queen, with her kits slowly going cold. They desperately try to save a kitten, but can't, and their mentor find them there sobbing hours later."
+            "app1 follows the strange sounds on the wind and finds the bodies of an unknown queen with their kits beside them, slowly going cold. They desperately try to save a kitten, but can't, and their mentor finds them there sobbing hours later."
     ],
     "win_skills": ["None"],
     "win_trait": ["None"],

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -970,7 +970,8 @@ class Patrol():
                     new_backstory=choice(['kittypet1', 'kittypet2'])
                     created_cats = self.create_new_cat(loner=False, loner_name=True, kittypet=True, queen=True, backstory=new_backstory)
                     new_cat = created_cats[0]
-                    new_cat.name = "unknown queen"
+                    new_cat.name.prefix = "unnamed"
+                    new_cat.name.suffix = " queen"
                     new_cat.outside = True
                     new_cat.dead = True
                 else:
@@ -979,7 +980,8 @@ class Patrol():
                                             'tragedy_survivor'])
                     created_cats = self.create_new_cat(loner=True, loner_name=True, kittypet=False, queen=True, backstory=new_backstory)
                     new_cat = created_cats[0]
-                    new_cat.name = "unknown queen"
+                    new_cat.name.prefix = "unnamed"
+                    new_cat.name.suffix = " queen"
                     new_cat.outside = True
                     new_cat.dead = True
                 if "new_cat_newborn" in tags:

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -1303,9 +1303,9 @@ class RelationshipScreen(Screens):
                 self.update_cat_page()
             elif event.ui_element == self.checkboxes["show_dead"]:
                 if game.settings['show dead relation']:
-                    game.settings['show dead relation'] = True
-                else:
                     game.settings['show dead relation'] = False
+                else:
+                    game.settings['show dead relation'] = True
                 self.update_checkboxes()
                 self.apply_cat_filter()
                 self.update_cat_page()


### PR DESCRIPTION
fixed new queen patrols and abandoned kit patrols using she/her pronouns and gendered terms such as mother. fixed a couple typos and grammar errors - commas, Starclan -> StarClan, misspellings