### PR TITLE
Additions: Tint and Inheritance

### DIFF
--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -105,7 +105,7 @@
 		"direct_inheritance": 15,
 		"wildcard_tortie": 9,
 		"vit_chance": 10,
-		"random_point_chance": 6
+		"random_point_chance": 0
 	},
 	"accessory_generation": {
 		"base_acc_chance": 150,
@@ -167,7 +167,7 @@
 		"cruel season_death_chance": 150
 	},
 	"clan_creation": {
-		"rerolls": 3,
+		"rerolls": -1,
 		"comment": "Set this to -1 for it to be infinite"
 	},
 	"graduation": {

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -167,7 +167,7 @@
 		"cruel season_death_chance": 150
 	},
 	"clan_creation": {
-		"rerolls": -1,
+		"rerolls": 3,
 		"comment": "Set this to -1 for it to be infinite"
 	},
 	"graduation": {

--- a/resources/game_config.json
+++ b/resources/game_config.json
@@ -105,7 +105,7 @@
 		"direct_inheritance": 15,
 		"wildcard_tortie": 9,
 		"vit_chance": 10,
-		"random_point_chance": 0
+		"random_point_chance": 6
 	},
 	"accessory_generation": {
 		"base_acc_chance": 150,

--- a/scripts/cat/appearance_utility.py
+++ b/scripts/cat/appearance_utility.py
@@ -210,6 +210,7 @@ def init_eyes(cat):
                 eye_choice = choice([yellow_eyes, blue_eyes])
                 cat.eye_colour2 = choice(eye_choice)
 
+
 def pelt_inheritance(cat, parents: tuple):
     # setting parent pelt categories
     #We are using a set, since we don't need this to be ordered, and sets deal with removing duplicates.
@@ -402,6 +403,7 @@ def pelt_inheritance(cat, parents: tuple):
     cat.pelt = choose_pelt(chosen_pelt_color, chosen_white, chosen_pelt, chosen_pelt_length)
     cat.tortiebase = chosen_tortie_base   # This will be none if the cat isn't a tortie.
 
+
 def randomize_pelt(cat):
     # ------------------------------------------------------------------------------------------------------------#
     #   PELT
@@ -465,6 +467,7 @@ def randomize_pelt(cat):
     cat.pelt = choose_pelt(chosen_pelt_color, chosen_white, chosen_pelt, chosen_pelt_length)
     cat.tortiebase = chosen_tortie_base   # This will be none if the cat isn't a tortie.
 
+
 def init_pelt(cat):
     if cat.pelt is not None:
         return cat.pelt
@@ -482,6 +485,7 @@ def init_pelt(cat):
             pelt_inheritance(cat, (par1, par2))
         else:
             randomize_pelt(cat)
+
 
 def init_sprite(cat):
     if cat.pelt is None:
@@ -675,31 +679,41 @@ def white_patches_inheritance(cat, parents: tuple):
     if cat.points and cat.white_patches in [high_white, mostly_white, 'FULLWHITE']:
         cat.points = None
 
+
 def randomize_white_patches(cat):
-    vit_chance = not random.getrandbits(game.config["cat_generation"]["vit_chance"])
-    if vit_chance:
+
+    # Vet determination
+    if not random.getrandbits(game.config["cat_generation"]["vit_chance"]):
         cat.vitiligo = choice(vit)
-    
-    point_chance = not random.getrandbits(game.config["cat_generation"]["random_point_chance"])
-    if point_chance:
+    else:
+        cat.vitiligo = None
+
+    # Points determination. Tortie can't be pointed
+    if cat.pelt.name != "Tortie" and not random.getrandbits(game.config["cat_generation"]["random_point_chance"]):
+        # Cat has colorpoint!
         cat.points = choice(point_markings)
 
-    # Adjust weights for torties, since they can't have anything greater than mid_white:
-    if cat.pelt.name == "Tortie":
-        weights = (2, 1, 0, 0, 0)
+        # Determination if they will have another white patch
+        if not int(random.random() * 20):
+            # The cat will also have white patches!
+            cat.white_patches = choice(little_white + mid_white)
+        else:
+            cat.white_patches = None
     else:
-        weights = (10, 10, 10, 10, 1)
+        # No colorpoint, normal
 
+        # Adjust weights for torties, since they can't have anything greater than mid_white:
+        if cat.pelt.name == "Tortie":
+            weights = (2, 1, 0, 0, 0)
+        else:
+            weights = (10, 10, 10, 10, 1)
 
-    white_list = [little_white, mid_white, high_white, mostly_white, ['FULLWHITE']]
-    chosen_white_patches = choice(
-        random.choices(white_list, weights=weights, k=1)[0]
-    )
+        white_list = [little_white, mid_white, high_white, mostly_white, ['FULLWHITE']]
+        chosen_white_patches = choice(
+            random.choices(white_list, weights=weights, k=1)[0]
+        )
 
-    cat.white_patches = chosen_white_patches
-
-    if cat.points and cat.white_patches in [high_white, mostly_white, 'FULLWHITE']:
-        cat.points = None
+        cat.white_patches = chosen_white_patches
 
 def init_white_patches(cat):
 
@@ -727,6 +741,7 @@ def init_white_patches(cat):
 def init_tint(cat):
     """Sets tint for pelt and white patches"""
 
+    # PELT TINT
     # Basic tints as possible for all colors.
     possible_tints = Sprites.cat_tints["possible_tints"]["basic"].copy()
     if cat.pelt.colour in Sprites.cat_tints["colour_groups"]:
@@ -736,10 +751,8 @@ def init_tint(cat):
     else:
         cat.tint = "none"
 
-    # These are the patches where the tint should always be none
-    no_tint_patches = ['SEPIAPOINT', 'MINKPOINT', 'SEALPOINT'] + vit
-
-    if cat.white_patches and cat.white_patches not in no_tint_patches:
+    # WHITE PATCHES TINT
+    if cat.white_patches or cat.points:
         #Now for white patches
         possible_tints = Sprites.white_patches_tints["possible_tints"]["basic"].copy()
         if cat.pelt.colour in Sprites.cat_tints["colour_groups"]:

--- a/scripts/cat/pelts.py
+++ b/scripts/cat/pelts.py
@@ -336,7 +336,7 @@ high_white = ['ANY', 'ANY2', 'BROKEN', 'FRECKLES', 'RINGTAIL', 'HALFFACE', 'PANT
               'CURVED', 'GLASS', 'MASKMANTLE', 'MAO', 'PAINTED']
 mostly_white = ['VAN', 'ONEEAR', 'LIGHTSONG', 'TAIL', 'HEART', 'MOORISH', 'APRON', 'CAPSADDLE',
                 'CHESTSPECK', 'BLACKSTAR', 'PETAL']
-point_markings = ['COLOURPOINT', 'RAGDOLL', 'SEPIAPOINT', 'MINKPOINT', 'SEALPOINT']
+point_markings = ['COLOURPOINT', 'RAGDOLL', 'SEPIAPOINT', 'MINKPOINT']
 vit = ['VITILIGO', 'VITILIGO2', 'MOON', 'PHANTOM', 'KARPATI']
 white_sprites = [
     little_white, mid_white, high_white, mostly_white, point_markings, vit, 'FULLWHITE']
@@ -540,6 +540,7 @@ def describe_color(pelt, tortiebase, tortiecolour, white_patches, points, vit):
         patches = tortiecolour.lower()
         color_name = f"{color_name} and {patches} tortie"
     elif pelt.name == "Calico":
+        patches = tortiecolour.lower()
         color_name = f'{color_name} and {patches} calico'
 
     if pelt.name in ['Tortie', 'Calico']:

--- a/scripts/cat/pelts.py
+++ b/scripts/cat/pelts.py
@@ -336,7 +336,7 @@ high_white = ['ANY', 'ANY2', 'BROKEN', 'FRECKLES', 'RINGTAIL', 'HALFFACE', 'PANT
               'CURVED', 'GLASS', 'MASKMANTLE', 'MAO', 'PAINTED']
 mostly_white = ['VAN', 'ONEEAR', 'LIGHTSONG', 'TAIL', 'HEART', 'MOORISH', 'APRON', 'CAPSADDLE',
                 'CHESTSPECK', 'BLACKSTAR', 'PETAL']
-point_markings = ['COLOURPOINT', 'RAGDOLL', 'SEPIAPOINT', 'MINKPOINT']
+point_markings = ['COLOURPOINT', 'RAGDOLL', 'SEPIAPOINT', 'MINKPOINT', 'SEALPOINT']
 vit = ['VITILIGO', 'VITILIGO2', 'MOON', 'PHANTOM', 'KARPATI']
 white_sprites = [
     little_white, mid_white, high_white, mostly_white, point_markings, vit, 'FULLWHITE']

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -234,8 +234,15 @@ def json_load():
 
         # Add faded siblings:
         for parent in cat.get_parents():
-            cat_ob = Cat.fetch_cat(parent)
-            cat.siblings.extend(cat_ob.faded_offspring)
+            try:
+                cat_ob = Cat.fetch_cat(parent)
+                cat.siblings.extend(cat_ob.faded_offspring)
+            except:
+                if parent == cat.parent1:
+                    cat.parent1 = None
+                elif parent == cat.parent2:
+                    cat.parent2 = None
+
         # Remove duplicates
         cat.siblings = list(set(cat.siblings))
 

--- a/scripts/utility.py
+++ b/scripts/utility.py
@@ -632,10 +632,19 @@ def update_sprite(cat):
             new_sprite.blit(white_patches, (0, 0))
 
         # draw vit & points
+
+        if cat.points:
+            points = sprites.sprites['white' + cat.points + cat_sprite].copy()
+            if cat.white_patches_tint != "none" and cat.white_patches_tint in Sprites.white_patches_tints[
+                 "tint_colours"]:
+                tint = pygame.Surface((50, 50)).convert_alpha()
+                tint.fill(tuple(Sprites.white_patches_tints["tint_colours"][cat.white_patches_tint]))
+                points.blit(tint, (0, 0), special_flags=pygame.BLEND_RGB_MULT)
+            new_sprite.blit(points, (0, 0))
+
+
         if cat.vitiligo:
             new_sprite.blit(sprites.sprites['white' + cat.vitiligo + cat_sprite], (0, 0))
-        if cat.points:
-            new_sprite.blit(sprites.sprites['white' + cat.points + cat_sprite], (0, 0))
 
         # draw eyes & scars1
         new_sprite.blit(sprites.sprites['eyes' + cat.eye_colour + cat_sprite], (0, 0))


### PR DESCRIPTION
- The white patches tint will now be applied to the point marking. 
- Added some inheritance stuff. 
- Ensured Calcios are limited to high_white and above, and make sure direct inheritance can't pass a white patch that is incompatible with Tortie or Calico. 